### PR TITLE
Fix Bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,6 +2509,8 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bce4ee5ee6c614994077e6e317270eab6fde2bc346b028290286cbf9d0011b7e"
 dependencies = [
  "hash-db",
  "log",
@@ -3297,3 +3299,8 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
+
+[[patch.unused]]
+name = "sp-state-machine"
+version = "0.35.0"
+source = "git+https://github.com/Quantus-Network/zk-state-machine#2dc9625b7419f225f5928c7944657fc1c67d5a07"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,8 +2509,6 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce4ee5ee6c614994077e6e317270eab6fde2bc346b028290286cbf9d0011b7e"
 dependencies = [
  "hash-db",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ schnellru = { version = "0.2.3", optional = true }
 
 [patch.crates-io]
 sp-trie = { path = "." }
+sp-state-machine = { path = "../zk-state-machine" }
 
 [dev-dependencies]
 array-bytes = { version = "6.2.2", default-features = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ schnellru = { version = "0.2.3", optional = true }
 
 [patch.crates-io]
 sp-trie = { path = "." }
-sp-state-machine = { path = "../zk-state-machine" }
+sp-state-machine = { git = "https://github.com/Quantus-Network/zk-state-machine" }
 
 [dev-dependencies]
 array-bytes = { version = "6.2.2", default-features = true }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,165 @@
-Utility functions to interact with Substrate's Base-16 Modified Merkle Patricia tree ("trie").
+# ZK-Trie: Zero-Knowledge Friendly Substrate Trie
 
-License: Apache-2.0
+A fork of Substrate's `sp-trie` modified to be zero-knowledge proof friendly by ensuring all data structures are aligned to 8-byte (felt) boundaries.
 
+## Overview
 
-## Release
+This is a customized implementation of Substrate's Patricia Merkle Trie (`sp-trie`) designed for zero-knowledge proof systems. The key modification is **felt-alignment**: all trie node structures are padded to 8-byte multiples, making them compatible with cryptographic field elements used in ZK proof systems.
 
-Polkadot SDK Stable 2412
+## Motivation
+
+### Why Fork sp-trie?
+
+Standard Substrate tries use compact encoding to minimize storage overhead, but this creates problems for zero-knowledge proof systems. The standard Substrate MPT uses compact encoding with variable-length headers and data which results in node structures being unaligned to cryptographic field boundaries. Verifying an inclusion proof requires finding the hash of a child node in the parent node and that hash may not be aligned to a 8-byte boundary. This repository fixes that.
+
+## Key Changes
+
+### 1. Fixed 8-Byte Headers
+
+**Before (Standard sp-trie):**
+```rust
+// Variable-length compact encoding
+let header = compact_encode(node_type, nibble_count);
+```
+
+**After (ZK-Trie):**
+```rust
+// Fixed 8-byte header
+#[derive(Encode, Decode)]
+enum NodeHeader {
+    Null,                           // Type 0
+    Branch(bool, usize),           // Type 1/2
+    Leaf(usize),                   // Type 3
+    HashedValueBranch(usize),      // Type 4
+    HashedValueLeaf(usize),        // Type 5
+}
+
+// Always encodes to exactly 8 bytes
+let header_bytes = header.encode(); // [8 bytes]
+```
+
+### 2. Felt-Aligned Data Padding
+
+**All data structures are padded to 8-byte boundaries:**
+
+```rust
+// Nibble data padding
+let nibble_bytes = (nibble_count + 1) / 2;
+let felt_aligned_bytes = ((nibble_bytes + 7) / 8) * 8;
+
+// Value data padding
+let value_len = value.len();
+let padded_len = ((value_len + 7) / 8) * 8;
+```
+
+### 3. Modified Node Structure
+
+**Standard Node:**
+```
+[compact_header][bitmap][nibbles][value][children...]
+child = [child_length][inlined_or_hashed_child]...
+```
+
+**ZK-Trie Node:**
+```
+[8_byte_header][felt_aligned_bitmap][felt_aligned_nibbles][felt_aligned_value][felt_aligned_children...]
+child = [8_byte_child_length][hashed_child]...
+```
+
+Note that there are no inlined children in ZK-Trie nodes. This is because the minimum size for a child node is now 32 bytes, the same size as the hash. The 8_byte_child_length could be removed in principle because the child hashes are all the same lengths, but to maintain consistency with the standard node structure, we left it in.
+
+## Usage
+
+### Integration with Substrate Runtime
+
+Replace the standard `sp-trie` dependency:
+
+```toml
+[dependencies]
+# sp-trie = "38.0.0"  # Standard version
+
+[patch.crates-io]
+sp-trie = { path = "path/to/zk-trie" }
+```
+
+This patching is necessary because sp-trie is a dependency of many Substrate packages.
+
+### Runtime Configuration
+
+If you want to use Poseidon for the storage root, do the following:
+
+```rust
+// Runtime configuration
+impl frame_system::Config for Runtime {
+    type Hashing = PoseidonHasher;  // ZK-friendly hasher
+    // ...
+}
+
+// Trie layout
+pub type LayoutV1 = sp_trie::LayoutV1<PoseidonHasher>;
+```
+
+### Logging
+
+The implementation includes targeted logging for debugging:
+
+```bash
+# View only zk-trie logs
+RUST_LOG=zk-trie=debug ./your-node --dev
+
+# Mix with other logs
+RUST_LOG=warn,zk-trie=debug ./your-node --dev
+```
+
+## Technical Details
+
+### Node Header Encoding
+
+The 8-byte header uses a structured format:
+
+```rust
+// Header structure (8 bytes)
+// Bits 63-60: Node type (4 bits)
+// Bits 31-0:  Nibble count (32 bits)
+// Bits 59-32: Reserved (28 bits)
+
+let header_value = (node_type << 60) | nibble_count;
+header_value.to_le_bytes()  // 8 bytes
+```
+
+### Memory Overhead
+
+The felt-alignment increases storage / memory requirements. Storage proofs are ~35% larger due to the padding.
+
+We consider this overhead acceptable for ZK applications where proof generation efficiency is more important than storage optimization.
+
+## Migration from Standard sp-trie
+
+### Clean Migration (Recommended)
+
+For development chains, start with a fresh database:
+
+```bash
+# Clean old database
+rm -rf /path/to/substrate/db
+
+# Start with zk-trie
+./your-node --dev --tmp
+```
+
+## Contributing
+
+When contributing to zk-trie:
+
+1. **Maintain felt-alignment**: All new data structures must be 8-byte aligned
+2. **Preserve compatibility**: Don't break the `sp-trie` API
+3. **Add tests**: Please don't change existing tests if possible
+4. **Update docs**: Document any changes to the encoding format
+
+## License
+
+Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for details.
+
+## Acknowledgments
+
+- Based on Substrate's `sp-trie` implementation by Parity Technologies

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,10 +48,10 @@ use hash_db::{Hasher, Prefix};
 pub use memory_db::{prefixed_key, HashKey, KeyFunction, PrefixedKey};
 /// The Substrate format implementation of `NodeCodec`.
 pub use node_codec::NodeCodec;
-pub use storage_proof::{CompactProof, StorageProof, StorageProofError};
+pub use storage_proof::{CompactProof, FeltAlignedCompactProof, NodeBoundary, StorageProof, StorageProofError};
 /// Trie codec reexport, mainly child trie support
 /// for trie compact proof.
-pub use trie_codec::{decode_compact, encode_compact, Error as CompactProofError};
+pub use trie_codec::{decode_compact, encode_compact, encode_felt_aligned_compact, Error as CompactProofError};
 use trie_db::proof::{generate_proof, verify_proof};
 /// Various re-exports from the `trie-db` crate.
 pub use trie_db::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,10 +48,10 @@ use hash_db::{Hasher, Prefix};
 pub use memory_db::{prefixed_key, HashKey, KeyFunction, PrefixedKey};
 /// The Substrate format implementation of `NodeCodec`.
 pub use node_codec::NodeCodec;
-pub use storage_proof::{CompactProof, FeltAlignedCompactProof, NodeBoundary, StorageProof, StorageProofError};
+pub use storage_proof::{CompactProof, StorageProof, StorageProofError};
 /// Trie codec reexport, mainly child trie support
 /// for trie compact proof.
-pub use trie_codec::{decode_compact, encode_compact, encode_felt_aligned_compact, Error as CompactProofError};
+pub use trie_codec::{decode_compact, encode_compact, Error as CompactProofError};
 use trie_db::proof::{generate_proof, verify_proof};
 /// Various re-exports from the `trie-db` crate.
 pub use trie_db::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,196 +206,194 @@ impl<H: Hasher, T: hash_db::AsHashDB<H, trie_db::DBValue>> AsHashDB<H> for T {}
 /// Reexport from `hash_db`, with genericity set for `Hasher` trait.
 pub type HashDB<'a, H> = dyn hash_db::HashDB<H, trie_db::DBValue> + 'a;
 /// ZK-trie compatible prefixed memory database with correct default initialization
-pub struct PrefixedMemoryDB<H: Hasher>(memory_db::MemoryDB<H, memory_db::PrefixedKey<H>, trie_db::DBValue>);
+pub struct PrefixedMemoryDB<H: Hasher>(
+    memory_db::MemoryDB<H, memory_db::PrefixedKey<H>, trie_db::DBValue>,
+);
 
 impl<H: Hasher> PrefixedMemoryDB<H> {
-	pub fn new(prefix: &[u8]) -> Self {
-		Self(memory_db::MemoryDB::new(prefix))
-	}
+    pub fn new(prefix: &[u8]) -> Self {
+        Self(memory_db::MemoryDB::new(prefix))
+    }
 
-	pub fn default_with_root() -> (Self, H::Out) {
-		let (inner_db, root) = memory_db::MemoryDB::default_with_root();
-		(Self(inner_db), root)
-	}
+    pub fn default_with_root() -> (Self, H::Out) {
+        let (inner_db, root) = memory_db::MemoryDB::default_with_root();
+        (Self(inner_db), root)
+    }
 
-	pub fn consolidate(&mut self, other: Self) {
-		self.0.consolidate(other.0)
-	}
+    pub fn consolidate(&mut self, other: Self) {
+        self.0.consolidate(other.0)
+    }
 }
 
 impl<H: Hasher> Clone for PrefixedMemoryDB<H> {
-	fn clone(&self) -> Self {
-		Self(self.0.clone())
-	}
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
 }
 
 impl<H: Hasher> Default for PrefixedMemoryDB<H> {
-	fn default() -> Self {
-		Self::new(&0u64.to_le_bytes())
-	}
+    fn default() -> Self {
+        Self::new(&0u64.to_le_bytes())
+    }
 }
 
 impl<H: Hasher> core::ops::Deref for PrefixedMemoryDB<H> {
-	type Target = memory_db::MemoryDB<H, memory_db::PrefixedKey<H>, trie_db::DBValue>;
-	fn deref(&self) -> &Self::Target {
-		&self.0
-	}
+    type Target = memory_db::MemoryDB<H, memory_db::PrefixedKey<H>, trie_db::DBValue>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl<H: Hasher> core::ops::DerefMut for PrefixedMemoryDB<H> {
-	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.0
-	}
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 impl<H: Hasher> hash_db::AsHashDB<H, trie_db::DBValue> for PrefixedMemoryDB<H> {
-	fn as_hash_db(&self) -> &dyn hash_db::HashDB<H, trie_db::DBValue> {
-		&self.0
-	}
+    fn as_hash_db(&self) -> &dyn hash_db::HashDB<H, trie_db::DBValue> {
+        &self.0
+    }
 
-	fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (dyn hash_db::HashDB<H, trie_db::DBValue> + 'a) {
-		&mut self.0
-	}
+    fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (dyn hash_db::HashDB<H, trie_db::DBValue> + 'a) {
+        &mut self.0
+    }
 }
 
 impl<H: Hasher> hash_db::AsHashDB<H, trie_db::DBValue> for &PrefixedMemoryDB<H> {
-	fn as_hash_db(&self) -> &dyn hash_db::HashDB<H, trie_db::DBValue> {
-		&self.0
-	}
+    fn as_hash_db(&self) -> &dyn hash_db::HashDB<H, trie_db::DBValue> {
+        &self.0
+    }
 
-	fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (dyn hash_db::HashDB<H, trie_db::DBValue> + 'a) {
-		unreachable!("Cannot get mutable reference from shared reference")
-	}
+    fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (dyn hash_db::HashDB<H, trie_db::DBValue> + 'a) {
+        unreachable!("Cannot get mutable reference from shared reference")
+    }
 }
 
 impl<H: Hasher> hash_db::HashDB<H, trie_db::DBValue> for PrefixedMemoryDB<H> {
-	fn get(&self, key: &H::Out, prefix: hash_db::Prefix) -> Option<trie_db::DBValue> {
-		hash_db::HashDB::get(&self.0, key, prefix)
-	}
+    fn get(&self, key: &H::Out, prefix: hash_db::Prefix) -> Option<trie_db::DBValue> {
+        hash_db::HashDB::get(&self.0, key, prefix)
+    }
 
-	fn contains(&self, key: &H::Out, prefix: hash_db::Prefix) -> bool {
-		hash_db::HashDB::contains(&self.0, key, prefix)
-	}
+    fn contains(&self, key: &H::Out, prefix: hash_db::Prefix) -> bool {
+        hash_db::HashDB::contains(&self.0, key, prefix)
+    }
 
-	fn insert(&mut self, prefix: hash_db::Prefix, value: &[u8]) -> H::Out {
-		hash_db::HashDB::insert(&mut self.0, prefix, value)
-	}
+    fn insert(&mut self, prefix: hash_db::Prefix, value: &[u8]) -> H::Out {
+        hash_db::HashDB::insert(&mut self.0, prefix, value)
+    }
 
-	fn emplace(&mut self, key: H::Out, prefix: hash_db::Prefix, value: trie_db::DBValue) {
-		hash_db::HashDB::emplace(&mut self.0, key, prefix, value)
-	}
+    fn emplace(&mut self, key: H::Out, prefix: hash_db::Prefix, value: trie_db::DBValue) {
+        hash_db::HashDB::emplace(&mut self.0, key, prefix, value)
+    }
 
-	fn remove(&mut self, key: &H::Out, prefix: hash_db::Prefix) {
-		hash_db::HashDB::remove(&mut self.0, key, prefix)
-	}
+    fn remove(&mut self, key: &H::Out, prefix: hash_db::Prefix) {
+        hash_db::HashDB::remove(&mut self.0, key, prefix)
+    }
 }
 
 impl<H: Hasher> hash_db::HashDBRef<H, trie_db::DBValue> for PrefixedMemoryDB<H> {
-	fn get(&self, key: &H::Out, prefix: hash_db::Prefix) -> Option<trie_db::DBValue> {
-		hash_db::HashDBRef::get(&self.0, key, prefix)
-	}
+    fn get(&self, key: &H::Out, prefix: hash_db::Prefix) -> Option<trie_db::DBValue> {
+        hash_db::HashDBRef::get(&self.0, key, prefix)
+    }
 
-	fn contains(&self, key: &H::Out, prefix: hash_db::Prefix) -> bool {
-		hash_db::HashDBRef::contains(&self.0, key, prefix)
-	}
+    fn contains(&self, key: &H::Out, prefix: hash_db::Prefix) -> bool {
+        hash_db::HashDBRef::contains(&self.0, key, prefix)
+    }
 }
-
 
 /// ZK-trie compatible memory database with correct default initialization
 pub struct MemoryDB<H: Hasher>(memory_db::MemoryDB<H, memory_db::HashKey<H>, trie_db::DBValue>);
 
 impl<H: Hasher> MemoryDB<H> {
-	pub fn new(prefix: &[u8]) -> Self {
-		Self(memory_db::MemoryDB::new(prefix))
-	}
+    pub fn new(prefix: &[u8]) -> Self {
+        Self(memory_db::MemoryDB::new(prefix))
+    }
 
-	pub fn consolidate(&mut self, other: Self) {
-		self.0.consolidate(other.0)
-	}
+    pub fn consolidate(&mut self, other: Self) {
+        self.0.consolidate(other.0)
+    }
 }
 
 impl<H: Hasher> Clone for MemoryDB<H> {
-	fn clone(&self) -> Self {
-		Self(self.0.clone())
-	}
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
 }
 
 impl<H: Hasher> Default for MemoryDB<H> {
-	fn default() -> Self {
-		Self::new(&0u64.to_le_bytes())
-	}
+    fn default() -> Self {
+        Self::new(&0u64.to_le_bytes())
+    }
 }
 
 impl<H: Hasher> core::ops::Deref for MemoryDB<H> {
-	type Target = memory_db::MemoryDB<H, memory_db::HashKey<H>, trie_db::DBValue>;
-	fn deref(&self) -> &Self::Target {
-		&self.0
-	}
+    type Target = memory_db::MemoryDB<H, memory_db::HashKey<H>, trie_db::DBValue>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl<H: Hasher> core::ops::DerefMut for MemoryDB<H> {
-	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.0
-	}
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 impl<H: Hasher> hash_db::AsHashDB<H, trie_db::DBValue> for MemoryDB<H> {
-	fn as_hash_db(&self) -> &dyn hash_db::HashDB<H, trie_db::DBValue> {
-		&self.0
-	}
+    fn as_hash_db(&self) -> &dyn hash_db::HashDB<H, trie_db::DBValue> {
+        &self.0
+    }
 
-	fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (dyn hash_db::HashDB<H, trie_db::DBValue> + 'a) {
-		&mut self.0
-	}
+    fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (dyn hash_db::HashDB<H, trie_db::DBValue> + 'a) {
+        &mut self.0
+    }
 }
 
 impl<H: Hasher> hash_db::AsHashDB<H, trie_db::DBValue> for &MemoryDB<H> {
-	fn as_hash_db(&self) -> &dyn hash_db::HashDB<H, trie_db::DBValue> {
-		&self.0
-	}
+    fn as_hash_db(&self) -> &dyn hash_db::HashDB<H, trie_db::DBValue> {
+        &self.0
+    }
 
-	fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (dyn hash_db::HashDB<H, trie_db::DBValue> + 'a) {
-		unreachable!("Cannot get mutable reference from shared reference")
-	}
+    fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (dyn hash_db::HashDB<H, trie_db::DBValue> + 'a) {
+        unreachable!("Cannot get mutable reference from shared reference")
+    }
 }
 
 impl<H: Hasher> hash_db::HashDB<H, trie_db::DBValue> for MemoryDB<H> {
-	fn get(&self, key: &H::Out, prefix: hash_db::Prefix) -> Option<trie_db::DBValue> {
-		hash_db::HashDB::get(&self.0, key, prefix)
-	}
+    fn get(&self, key: &H::Out, prefix: hash_db::Prefix) -> Option<trie_db::DBValue> {
+        hash_db::HashDB::get(&self.0, key, prefix)
+    }
 
-	fn contains(&self, key: &H::Out, prefix: hash_db::Prefix) -> bool {
-		hash_db::HashDB::contains(&self.0, key, prefix)
-	}
+    fn contains(&self, key: &H::Out, prefix: hash_db::Prefix) -> bool {
+        hash_db::HashDB::contains(&self.0, key, prefix)
+    }
 
-	fn insert(&mut self, prefix: hash_db::Prefix, value: &[u8]) -> H::Out {
-		hash_db::HashDB::insert(&mut self.0, prefix, value)
-	}
+    fn insert(&mut self, prefix: hash_db::Prefix, value: &[u8]) -> H::Out {
+        hash_db::HashDB::insert(&mut self.0, prefix, value)
+    }
 
-	fn emplace(&mut self, key: H::Out, prefix: hash_db::Prefix, value: trie_db::DBValue) {
-		hash_db::HashDB::emplace(&mut self.0, key, prefix, value)
-	}
+    fn emplace(&mut self, key: H::Out, prefix: hash_db::Prefix, value: trie_db::DBValue) {
+        hash_db::HashDB::emplace(&mut self.0, key, prefix, value)
+    }
 
-	fn remove(&mut self, key: &H::Out, prefix: hash_db::Prefix) {
-		hash_db::HashDB::remove(&mut self.0, key, prefix)
-	}
+    fn remove(&mut self, key: &H::Out, prefix: hash_db::Prefix) {
+        hash_db::HashDB::remove(&mut self.0, key, prefix)
+    }
 }
 
 impl<H: Hasher> hash_db::HashDBRef<H, trie_db::DBValue> for MemoryDB<H> {
-	fn get(&self, key: &H::Out, prefix: hash_db::Prefix) -> Option<trie_db::DBValue> {
-		hash_db::HashDBRef::get(&self.0, key, prefix)
-	}
+    fn get(&self, key: &H::Out, prefix: hash_db::Prefix) -> Option<trie_db::DBValue> {
+        hash_db::HashDBRef::get(&self.0, key, prefix)
+    }
 
-	fn contains(&self, key: &H::Out, prefix: hash_db::Prefix) -> bool {
-		hash_db::HashDBRef::contains(&self.0, key, prefix)
-	}
+    fn contains(&self, key: &H::Out, prefix: hash_db::Prefix) -> bool {
+        hash_db::HashDBRef::contains(&self.0, key, prefix)
+    }
 }
-
 
 /// Reexport from `hash_db`, with genericity set for `Hasher` trait.
 pub type GenericMemoryDB<H, KF> = memory_db::MemoryDB<H, KF, trie_db::DBValue>;
-
-
 
 /// Persistent trie database read-access interface for a given hasher.
 pub type TrieDB<'a, 'cache, L> = trie_db::TrieDB<'a, 'cache, L>;
@@ -1322,7 +1320,7 @@ mod tests {
     fn check_branch_node_child_positions<L: TrieConfiguration>(
         node_data: &[u8],
         children: &[Option<trie_db::node::NodeHandlePlan>; 16],
-        child_refs_checked: &mut usize
+        child_refs_checked: &mut usize,
     ) {
         use crate::NodeCodec;
 
@@ -1885,7 +1883,7 @@ mod tests {
     }
 
     fn test_reproduce_incomplete_database_scenarios_inner<L: TrieConfiguration>() {
-        use memory_db::{MemoryDB, HashKey};
+        use memory_db::{HashKey, MemoryDB};
         use trie_db::{TrieDBMutBuilder, TrieMut};
 
         let mut memdb = MemoryDBMeta::<L::Hash>::new(&0u64.to_le_bytes());
@@ -1896,16 +1894,23 @@ mod tests {
             let mut trie = TrieDBMutBuilder::<L>::new(&mut memdb, &mut root).build();
 
             // These are the exact insertions that were failing in the balance tests
-            trie.insert(b"value3", &[142; 33]).expect("insert failed - 33 byte array");
-            trie.insert(b"value4", &[124; 33]).expect("insert failed - 33 byte array");
-            trie.insert(b"key", b"value").expect("insert failed - string value");
-            trie.insert(b"value1", &[42]).expect("insert failed - 1 byte");
-            trie.insert(b"value2", &[24]).expect("insert failed - 1 byte");
-            trie.insert(b":code", b"return 42").expect("insert failed - code string");
+            trie.insert(b"value3", &[142; 33])
+                .expect("insert failed - 33 byte array");
+            trie.insert(b"value4", &[124; 33])
+                .expect("insert failed - 33 byte array");
+            trie.insert(b"key", b"value")
+                .expect("insert failed - string value");
+            trie.insert(b"value1", &[42])
+                .expect("insert failed - 1 byte");
+            trie.insert(b"value2", &[24])
+                .expect("insert failed - 1 byte");
+            trie.insert(b":code", b"return 42")
+                .expect("insert failed - code string");
 
             // Insert range like in the failing tests
             for i in 128u8..255u8 {
-                trie.insert(&[i], &[i]).expect(&format!("insert failed for {}", i));
+                trie.insert(&[i], &[i])
+                    .expect(&format!("insert failed for {}", i));
             }
         }
 
@@ -1927,18 +1932,23 @@ mod tests {
     }
 
     fn test_child_trie_root_handling_inner<L: TrieConfiguration>() {
-        use memory_db::{MemoryDB, HashKey, PrefixedKey};
-        use trie_db::{TrieDBMutBuilder, TrieMut};
         use codec::Encode;
+        use memory_db::{HashKey, MemoryDB, PrefixedKey};
+        use trie_db::{TrieDBMutBuilder, TrieMut};
 
         // Step 1: Build a child trie (mimicking the test_db pattern)
         let mut child_memdb = MemoryDBMeta::<L::Hash>::new(&0u64.to_le_bytes());
         let mut child_root = Default::default();
 
         {
-            let mut child_trie = TrieDBMutBuilder::<L>::new(&mut child_memdb, &mut child_root).build();
-            child_trie.insert(b"value3", &[142; 33]).expect("child insert failed");
-            child_trie.insert(b"value4", &[124; 33]).expect("child insert failed");
+            let mut child_trie =
+                TrieDBMutBuilder::<L>::new(&mut child_memdb, &mut child_root).build();
+            child_trie
+                .insert(b"value3", &[142; 33])
+                .expect("child insert failed");
+            child_trie
+                .insert(b"value4", &[124; 33])
+                .expect("child insert failed");
         }
 
         // Step 2: Encode the child root like in the failing test
@@ -1953,16 +1963,22 @@ mod tests {
 
             // This pattern was causing IncompleteDatabase errors
             let child_storage_key = b":child_storage_default:child";
-            main_trie.insert(child_storage_key, &sub_root).expect("main trie insert of child root failed");
+            main_trie
+                .insert(child_storage_key, &sub_root)
+                .expect("main trie insert of child root failed");
 
             // Add other data like in the failing test
             main_trie.insert(b"key", b"value").expect("insert failed");
             main_trie.insert(b"value1", &[42]).expect("insert failed");
             main_trie.insert(b"value2", &[24]).expect("insert failed");
-            main_trie.insert(b":code", b"return 42").expect("insert failed");
+            main_trie
+                .insert(b":code", b"return 42")
+                .expect("insert failed");
 
             for i in 128u8..255u8 {
-                main_trie.insert(&[i], &[i]).expect(&format!("insert failed for {}", i));
+                main_trie
+                    .insert(&[i], &[i])
+                    .expect(&format!("insert failed for {}", i));
             }
         }
 
@@ -1979,7 +1995,7 @@ mod tests {
     }
 
     fn test_unaligned_value_insertion_edge_cases_inner<L: TrieConfiguration>() {
-        use memory_db::{MemoryDB, HashKey};
+        use memory_db::{HashKey, MemoryDB};
         use trie_db::{TrieDBMutBuilder, TrieMut};
 
         let mut memdb = MemoryDBMeta::<L::Hash>::new(&0u64.to_le_bytes());
@@ -2002,11 +2018,13 @@ mod tests {
             ];
 
             for (key, value) in &test_cases {
-                trie.insert(key, value).expect(&format!("Failed to insert {} bytes", value.len()));
+                trie.insert(key, value)
+                    .expect(&format!("Failed to insert {} bytes", value.len()));
             }
 
             // Also test the exact pattern from the failing balance tests
-            trie.insert(b"balance_key", &[142; 33]).expect("balance-like insert failed");
+            trie.insert(b"balance_key", &[142; 33])
+                .expect("balance-like insert failed");
         }
 
         // Verify round-trip consistency
@@ -2026,8 +2044,12 @@ mod tests {
 
         for (key, expected_value) in &test_cases {
             let stored_value = trie.get(key).unwrap();
-            assert_eq!(stored_value, Some(expected_value.clone()),
-                      "Round-trip failed for {} byte value", expected_value.len());
+            assert_eq!(
+                stored_value,
+                Some(expected_value.clone()),
+                "Round-trip failed for {} byte value",
+                expected_value.len()
+            );
         }
 
         assert_eq!(trie.get(b"balance_key").unwrap(), Some(vec![142; 33]));
@@ -2041,37 +2063,42 @@ mod tests {
 
     fn test_encode_decode_round_trip_consistency_inner<L: TrieConfiguration>() {
         use crate::NodeCodec;
+        use trie_db::node::{NodePlan, Value};
         use trie_db::NodeCodec as NodeCodecT;
-        use trie_db::node::{Value, NodePlan};
 
         // Test round-trip for various problematic value sizes
         let test_values = vec![
-            vec![],           // 0 bytes
-            vec![42],         // 1 byte
-            vec![1, 2, 3],    // 3 bytes
-            vec![1; 5],       // 5 bytes
-            vec![1; 7],       // 7 bytes
-            vec![1; 9],       // 9 bytes
-            vec![142; 33],    // 33 bytes (from failing test)
-            vec![1; 65],      // 65 bytes
+            vec![],        // 0 bytes
+            vec![42],      // 1 byte
+            vec![1, 2, 3], // 3 bytes
+            vec![1; 5],    // 5 bytes
+            vec![1; 7],    // 7 bytes
+            vec![1; 9],    // 9 bytes
+            vec![142; 33], // 33 bytes (from failing test)
+            vec![1; 65],   // 65 bytes
         ];
 
         for value in test_values {
             // Test leaf node encoding/decoding
-            let encoded = NodeCodec::<L::Hash>::leaf_node(
-                [0xaa].iter().copied(),
-                2,
-                Value::Inline(&value)
-            );
+            let encoded =
+                NodeCodec::<L::Hash>::leaf_node([0xaa].iter().copied(), 2, Value::Inline(&value));
 
             let decoded = NodeCodec::<L::Hash>::decode_plan(&encoded)
                 .expect(&format!("Failed to decode {} byte value", value.len()));
 
-            if let NodePlan::Leaf { value: decoded_value, .. } = decoded {
+            if let NodePlan::Leaf {
+                value: decoded_value,
+                ..
+            } = decoded
+            {
                 if let trie_db::node::ValuePlan::Inline(range) = decoded_value {
                     let decoded_bytes = &encoded[range];
-                    assert_eq!(decoded_bytes, &value[..],
-                              "Round-trip mismatch for {} byte value", value.len());
+                    assert_eq!(
+                        decoded_bytes,
+                        &value[..],
+                        "Round-trip mismatch for {} byte value",
+                        value.len()
+                    );
                 } else {
                     panic!("Expected inline value for {} bytes", value.len());
                 }
@@ -2088,7 +2115,7 @@ mod tests {
     }
 
     fn test_minimal_single_insert_inner<L: TrieConfiguration>() {
-        use memory_db::{MemoryDB, HashKey};
+        use memory_db::{HashKey, MemoryDB};
         use trie_db::{TrieDBMutBuilder, TrieMut};
 
         let mut memdb = MemoryDBMeta::<L::Hash>::new(&0u64.to_le_bytes());
@@ -2100,7 +2127,8 @@ mod tests {
 
             // Start with the exact failing case
             println!("Attempting to insert single problematic value...");
-            trie.insert(b"value3", &[142; 33]).expect("MINIMAL SINGLE INSERT FAILED");
+            trie.insert(b"value3", &[142; 33])
+                .expect("MINIMAL SINGLE INSERT FAILED");
             println!("✓ Single insert succeeded");
         }
 
@@ -2118,7 +2146,7 @@ mod tests {
     }
 
     fn test_progressive_inserts_inner<L: TrieConfiguration>() {
-        use memory_db::{MemoryDB, HashKey};
+        use memory_db::{HashKey, MemoryDB};
         use trie_db::{TrieDBMutBuilder, TrieMut};
 
         let mut memdb = MemoryDBMeta::<L::Hash>::new(&0u64.to_le_bytes());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,16 +205,192 @@ pub trait AsHashDB<H: Hasher>: hash_db::AsHashDB<H, trie_db::DBValue> {}
 impl<H: Hasher, T: hash_db::AsHashDB<H, trie_db::DBValue>> AsHashDB<H> for T {}
 /// Reexport from `hash_db`, with genericity set for `Hasher` trait.
 pub type HashDB<'a, H> = dyn hash_db::HashDB<H, trie_db::DBValue> + 'a;
-/// Reexport from `hash_db`, with genericity set for `Hasher` trait.
-/// This uses a `KeyFunction` for prefixing keys internally (avoiding
-/// key conflict for non random keys).
-pub type PrefixedMemoryDB<H> = memory_db::MemoryDB<H, memory_db::PrefixedKey<H>, trie_db::DBValue>;
-/// Reexport from `hash_db`, with genericity set for `Hasher` trait.
-/// This uses a noops `KeyFunction` (key addressing must be hashed or using
-/// an encoding scheme that avoid key conflict).
-pub type MemoryDB<H> = memory_db::MemoryDB<H, memory_db::HashKey<H>, trie_db::DBValue>;
+/// ZK-trie compatible prefixed memory database with correct default initialization
+pub struct PrefixedMemoryDB<H: Hasher>(memory_db::MemoryDB<H, memory_db::PrefixedKey<H>, trie_db::DBValue>);
+
+impl<H: Hasher> PrefixedMemoryDB<H> {
+	pub fn new(prefix: &[u8]) -> Self {
+		Self(memory_db::MemoryDB::new(prefix))
+	}
+
+	pub fn consolidate(&mut self, other: Self) {
+		self.0.consolidate(other.0)
+	}
+}
+
+impl<H: Hasher> Clone for PrefixedMemoryDB<H> {
+	fn clone(&self) -> Self {
+		Self(self.0.clone())
+	}
+}
+
+impl<H: Hasher> Default for PrefixedMemoryDB<H> {
+	fn default() -> Self {
+		Self::new(&0u64.to_le_bytes())
+	}
+}
+
+impl<H: Hasher> std::ops::Deref for PrefixedMemoryDB<H> {
+	type Target = memory_db::MemoryDB<H, memory_db::PrefixedKey<H>, trie_db::DBValue>;
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl<H: Hasher> std::ops::DerefMut for PrefixedMemoryDB<H> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.0
+	}
+}
+
+impl<H: Hasher> hash_db::AsHashDB<H, trie_db::DBValue> for PrefixedMemoryDB<H> {
+	fn as_hash_db(&self) -> &dyn hash_db::HashDB<H, trie_db::DBValue> {
+		&self.0
+	}
+
+	fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (dyn hash_db::HashDB<H, trie_db::DBValue> + 'a) {
+		&mut self.0
+	}
+}
+
+impl<H: Hasher> hash_db::AsHashDB<H, trie_db::DBValue> for &PrefixedMemoryDB<H> {
+	fn as_hash_db(&self) -> &dyn hash_db::HashDB<H, trie_db::DBValue> {
+		&self.0
+	}
+
+	fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (dyn hash_db::HashDB<H, trie_db::DBValue> + 'a) {
+		unreachable!("Cannot get mutable reference from shared reference")
+	}
+}
+
+impl<H: Hasher> hash_db::HashDB<H, trie_db::DBValue> for PrefixedMemoryDB<H> {
+	fn get(&self, key: &H::Out, prefix: hash_db::Prefix) -> Option<trie_db::DBValue> {
+		hash_db::HashDB::get(&self.0, key, prefix)
+	}
+
+	fn contains(&self, key: &H::Out, prefix: hash_db::Prefix) -> bool {
+		hash_db::HashDB::contains(&self.0, key, prefix)
+	}
+
+	fn insert(&mut self, prefix: hash_db::Prefix, value: &[u8]) -> H::Out {
+		hash_db::HashDB::insert(&mut self.0, prefix, value)
+	}
+
+	fn emplace(&mut self, key: H::Out, prefix: hash_db::Prefix, value: trie_db::DBValue) {
+		hash_db::HashDB::emplace(&mut self.0, key, prefix, value)
+	}
+
+	fn remove(&mut self, key: &H::Out, prefix: hash_db::Prefix) {
+		hash_db::HashDB::remove(&mut self.0, key, prefix)
+	}
+}
+
+impl<H: Hasher> hash_db::HashDBRef<H, trie_db::DBValue> for PrefixedMemoryDB<H> {
+	fn get(&self, key: &H::Out, prefix: hash_db::Prefix) -> Option<trie_db::DBValue> {
+		hash_db::HashDBRef::get(&self.0, key, prefix)
+	}
+
+	fn contains(&self, key: &H::Out, prefix: hash_db::Prefix) -> bool {
+		hash_db::HashDBRef::contains(&self.0, key, prefix)
+	}
+}
+
+
+/// ZK-trie compatible memory database with correct default initialization
+pub struct MemoryDB<H: Hasher>(memory_db::MemoryDB<H, memory_db::HashKey<H>, trie_db::DBValue>);
+
+impl<H: Hasher> MemoryDB<H> {
+	pub fn new(prefix: &[u8]) -> Self {
+		Self(memory_db::MemoryDB::new(prefix))
+	}
+
+	pub fn consolidate(&mut self, other: Self) {
+		self.0.consolidate(other.0)
+	}
+}
+
+impl<H: Hasher> Clone for MemoryDB<H> {
+	fn clone(&self) -> Self {
+		Self(self.0.clone())
+	}
+}
+
+impl<H: Hasher> Default for MemoryDB<H> {
+	fn default() -> Self {
+		Self::new(&0u64.to_le_bytes())
+	}
+}
+
+impl<H: Hasher> std::ops::Deref for MemoryDB<H> {
+	type Target = memory_db::MemoryDB<H, memory_db::HashKey<H>, trie_db::DBValue>;
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl<H: Hasher> std::ops::DerefMut for MemoryDB<H> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.0
+	}
+}
+
+impl<H: Hasher> hash_db::AsHashDB<H, trie_db::DBValue> for MemoryDB<H> {
+	fn as_hash_db(&self) -> &dyn hash_db::HashDB<H, trie_db::DBValue> {
+		&self.0
+	}
+
+	fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (dyn hash_db::HashDB<H, trie_db::DBValue> + 'a) {
+		&mut self.0
+	}
+}
+
+impl<H: Hasher> hash_db::AsHashDB<H, trie_db::DBValue> for &MemoryDB<H> {
+	fn as_hash_db(&self) -> &dyn hash_db::HashDB<H, trie_db::DBValue> {
+		&self.0
+	}
+
+	fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (dyn hash_db::HashDB<H, trie_db::DBValue> + 'a) {
+		unreachable!("Cannot get mutable reference from shared reference")
+	}
+}
+
+impl<H: Hasher> hash_db::HashDB<H, trie_db::DBValue> for MemoryDB<H> {
+	fn get(&self, key: &H::Out, prefix: hash_db::Prefix) -> Option<trie_db::DBValue> {
+		hash_db::HashDB::get(&self.0, key, prefix)
+	}
+
+	fn contains(&self, key: &H::Out, prefix: hash_db::Prefix) -> bool {
+		hash_db::HashDB::contains(&self.0, key, prefix)
+	}
+
+	fn insert(&mut self, prefix: hash_db::Prefix, value: &[u8]) -> H::Out {
+		hash_db::HashDB::insert(&mut self.0, prefix, value)
+	}
+
+	fn emplace(&mut self, key: H::Out, prefix: hash_db::Prefix, value: trie_db::DBValue) {
+		hash_db::HashDB::emplace(&mut self.0, key, prefix, value)
+	}
+
+	fn remove(&mut self, key: &H::Out, prefix: hash_db::Prefix) {
+		hash_db::HashDB::remove(&mut self.0, key, prefix)
+	}
+}
+
+impl<H: Hasher> hash_db::HashDBRef<H, trie_db::DBValue> for MemoryDB<H> {
+	fn get(&self, key: &H::Out, prefix: hash_db::Prefix) -> Option<trie_db::DBValue> {
+		hash_db::HashDBRef::get(&self.0, key, prefix)
+	}
+
+	fn contains(&self, key: &H::Out, prefix: hash_db::Prefix) -> bool {
+		hash_db::HashDBRef::contains(&self.0, key, prefix)
+	}
+}
+
+
 /// Reexport from `hash_db`, with genericity set for `Hasher` trait.
 pub type GenericMemoryDB<H, KF> = memory_db::MemoryDB<H, KF, trie_db::DBValue>;
+
+
 
 /// Persistent trie database read-access interface for a given hasher.
 pub type TrieDB<'a, 'cache, L> = trie_db::TrieDB<'a, 'cache, L>;
@@ -1633,5 +1809,275 @@ mod tests {
             result.is_err(),
             "Decoding with insufficient bytes should fail"
         );
+    }
+
+    #[test]
+    fn test_reproduce_incomplete_database_scenarios() {
+        // Test scenarios that mimic the failing balance tests
+        test_reproduce_incomplete_database_scenarios_inner::<LayoutV1>();
+        test_reproduce_incomplete_database_scenarios_inner::<LayoutV0>();
+    }
+
+    fn test_reproduce_incomplete_database_scenarios_inner<L: TrieConfiguration>() {
+        use memory_db::{MemoryDB, HashKey};
+        use trie_db::{TrieDBMutBuilder, TrieMut};
+        
+        let mut memdb = MemoryDBMeta::<L::Hash>::new(&0u64.to_le_bytes());
+        let mut root = Default::default();
+        
+        // Test inserting the exact problematic data from failing tests
+        {
+            let mut trie = TrieDBMutBuilder::<L>::new(&mut memdb, &mut root).build();
+            
+            // These are the exact insertions that were failing in the balance tests
+            trie.insert(b"value3", &[142; 33]).expect("insert failed - 33 byte array");
+            trie.insert(b"value4", &[124; 33]).expect("insert failed - 33 byte array");
+            trie.insert(b"key", b"value").expect("insert failed - string value");
+            trie.insert(b"value1", &[42]).expect("insert failed - 1 byte");
+            trie.insert(b"value2", &[24]).expect("insert failed - 1 byte");
+            trie.insert(b":code", b"return 42").expect("insert failed - code string");
+            
+            // Insert range like in the failing tests
+            for i in 128u8..255u8 {
+                trie.insert(&[i], &[i]).expect(&format!("insert failed for {}", i));
+            }
+        }
+        
+        // Verify we can read everything back
+        let trie = trie_db::TrieDBBuilder::<L>::new(&memdb, &root).build();
+        assert_eq!(trie.get(b"value3").unwrap(), Some(vec![142; 33]));
+        assert_eq!(trie.get(b"value4").unwrap(), Some(vec![124; 33]));
+        assert_eq!(trie.get(b"key").unwrap(), Some(b"value".to_vec()));
+        assert_eq!(trie.get(b"value1").unwrap(), Some(vec![42]));
+        assert_eq!(trie.get(b"value2").unwrap(), Some(vec![24]));
+        assert_eq!(trie.get(b":code").unwrap(), Some(b"return 42".to_vec()));
+    }
+
+    #[test]
+    fn test_child_trie_root_handling() {
+        // Test the child trie pattern that was failing in sp-state-machine
+        test_child_trie_root_handling_inner::<LayoutV1>();
+        test_child_trie_root_handling_inner::<LayoutV0>();
+    }
+
+    fn test_child_trie_root_handling_inner<L: TrieConfiguration>() {
+        use memory_db::{MemoryDB, HashKey, PrefixedKey};
+        use trie_db::{TrieDBMutBuilder, TrieMut};
+        use codec::Encode;
+        
+        // Step 1: Build a child trie (mimicking the test_db pattern)
+        let mut child_memdb = MemoryDBMeta::<L::Hash>::new(&0u64.to_le_bytes());
+        let mut child_root = Default::default();
+        
+        {
+            let mut child_trie = TrieDBMutBuilder::<L>::new(&mut child_memdb, &mut child_root).build();
+            child_trie.insert(b"value3", &[142; 33]).expect("child insert failed");
+            child_trie.insert(b"value4", &[124; 33]).expect("child insert failed");
+        }
+        
+        // Step 2: Encode the child root like in the failing test
+        let sub_root = child_root.as_ref().to_vec();
+        
+        // Step 3: Insert the child root as a value in a main trie
+        let mut main_memdb = MemoryDBMeta::<L::Hash>::new(&0u64.to_le_bytes());
+        let mut main_root = Default::default();
+        
+        {
+            let mut main_trie = TrieDBMutBuilder::<L>::new(&mut main_memdb, &mut main_root).build();
+            
+            // This pattern was causing IncompleteDatabase errors
+            let child_storage_key = b":child_storage_default:child";
+            main_trie.insert(child_storage_key, &sub_root).expect("main trie insert of child root failed");
+            
+            // Add other data like in the failing test
+            main_trie.insert(b"key", b"value").expect("insert failed");
+            main_trie.insert(b"value1", &[42]).expect("insert failed");
+            main_trie.insert(b"value2", &[24]).expect("insert failed");
+            main_trie.insert(b":code", b"return 42").expect("insert failed");
+            
+            for i in 128u8..255u8 {
+                main_trie.insert(&[i], &[i]).expect(&format!("insert failed for {}", i));
+            }
+        }
+        
+        // Verify we can read the child root back
+        let main_trie = trie_db::TrieDBBuilder::<L>::new(&main_memdb, &main_root).build();
+        let stored_child_root = main_trie.get(b":child_storage_default:child").unwrap();
+        assert_eq!(stored_child_root, Some(sub_root));
+    }
+
+    #[test] 
+    fn test_unaligned_value_insertion_edge_cases() {
+        test_unaligned_value_insertion_edge_cases_inner::<LayoutV1>();
+        test_unaligned_value_insertion_edge_cases_inner::<LayoutV0>();
+    }
+
+    fn test_unaligned_value_insertion_edge_cases_inner<L: TrieConfiguration>() {
+        use memory_db::{MemoryDB, HashKey};
+        use trie_db::{TrieDBMutBuilder, TrieMut};
+        
+        let mut memdb = MemoryDBMeta::<L::Hash>::new(&0u64.to_le_bytes());
+        let mut root = Default::default();
+        
+        {
+            let mut trie = TrieDBMutBuilder::<L>::new(&mut memdb, &mut root).build();
+            
+            // Test various problematic sizes that aren't 8-byte aligned
+            let test_cases = vec![
+                (b"empty".as_slice(), vec![]),                    // 0 bytes
+                (b"one".as_slice(), vec![42]),                    // 1 byte
+                (b"two".as_slice(), vec![42, 43]),                // 2 bytes
+                (b"three".as_slice(), vec![42, 43, 44]),          // 3 bytes
+                (b"five".as_slice(), vec![1, 2, 3, 4, 5]),        // 5 bytes
+                (b"seven".as_slice(), vec![1, 2, 3, 4, 5, 6, 7]), // 7 bytes
+                (b"nine".as_slice(), vec![1; 9]),                 // 9 bytes (8 + 1)
+                (b"thirtythree".as_slice(), vec![142; 33]),       // 33 bytes (like failing test)
+                (b"sixtyfive".as_slice(), vec![200; 65]),         // 65 bytes (64 + 1)
+            ];
+            
+            for (key, value) in &test_cases {
+                trie.insert(key, value).expect(&format!("Failed to insert {} bytes", value.len()));
+            }
+            
+            // Also test the exact pattern from the failing balance tests
+            trie.insert(b"balance_key", &[142; 33]).expect("balance-like insert failed");
+        }
+        
+        // Verify round-trip consistency
+        let trie = trie_db::TrieDBBuilder::<L>::new(&memdb, &root).build();
+        
+        let test_cases = vec![
+            (b"empty".as_slice(), vec![]),
+            (b"one".as_slice(), vec![42]),
+            (b"two".as_slice(), vec![42, 43]),
+            (b"three".as_slice(), vec![42, 43, 44]),
+            (b"five".as_slice(), vec![1, 2, 3, 4, 5]),
+            (b"seven".as_slice(), vec![1, 2, 3, 4, 5, 6, 7]),
+            (b"nine".as_slice(), vec![1; 9]),
+            (b"thirtythree".as_slice(), vec![142; 33]),
+            (b"sixtyfive".as_slice(), vec![200; 65]),
+        ];
+        
+        for (key, expected_value) in &test_cases {
+            let stored_value = trie.get(key).unwrap();
+            assert_eq!(stored_value, Some(expected_value.clone()), 
+                      "Round-trip failed for {} byte value", expected_value.len());
+        }
+        
+        assert_eq!(trie.get(b"balance_key").unwrap(), Some(vec![142; 33]));
+    }
+
+    #[test]
+    fn test_encode_decode_round_trip_consistency() {
+        test_encode_decode_round_trip_consistency_inner::<LayoutV1>();
+        test_encode_decode_round_trip_consistency_inner::<LayoutV0>();
+    }
+
+    fn test_encode_decode_round_trip_consistency_inner<L: TrieConfiguration>() {
+        use crate::NodeCodec;
+        use trie_db::NodeCodec as NodeCodecT;
+        use trie_db::node::{Value, NodePlan};
+        
+        // Test round-trip for various problematic value sizes
+        let test_values = vec![
+            vec![],           // 0 bytes
+            vec![42],         // 1 byte  
+            vec![1, 2, 3],    // 3 bytes
+            vec![1; 5],       // 5 bytes
+            vec![1; 7],       // 7 bytes
+            vec![1; 9],       // 9 bytes
+            vec![142; 33],    // 33 bytes (from failing test)
+            vec![1; 65],      // 65 bytes
+        ];
+        
+        for value in test_values {
+            // Test leaf node encoding/decoding
+            let encoded = NodeCodec::<L::Hash>::leaf_node(
+                [0xaa].iter().copied(), 
+                2, 
+                Value::Inline(&value)
+            );
+            
+            let decoded = NodeCodec::<L::Hash>::decode_plan(&encoded)
+                .expect(&format!("Failed to decode {} byte value", value.len()));
+            
+            if let NodePlan::Leaf { value: decoded_value, .. } = decoded {
+                if let trie_db::node::ValuePlan::Inline(range) = decoded_value {
+                    let decoded_bytes = &encoded[range];
+                    assert_eq!(decoded_bytes, &value[..], 
+                              "Round-trip mismatch for {} byte value", value.len());
+                } else {
+                    panic!("Expected inline value for {} bytes", value.len());
+                }
+            } else {
+                panic!("Expected leaf node");
+            }
+        }
+    }
+
+    #[test]
+    fn test_minimal_single_insert() {
+        test_minimal_single_insert_inner::<LayoutV1>();
+        test_minimal_single_insert_inner::<LayoutV0>();
+    }
+
+    fn test_minimal_single_insert_inner<L: TrieConfiguration>() {
+        use memory_db::{MemoryDB, HashKey};
+        use trie_db::{TrieDBMutBuilder, TrieMut};
+        
+        let mut memdb = MemoryDBMeta::<L::Hash>::new(&0u64.to_le_bytes());
+        let mut root = Default::default();
+        
+        // Try the absolute simplest case first
+        {
+            let mut trie = TrieDBMutBuilder::<L>::new(&mut memdb, &mut root).build();
+            
+            // Start with the exact failing case
+            println!("Attempting to insert single problematic value...");
+            trie.insert(b"value3", &[142; 33]).expect("MINIMAL SINGLE INSERT FAILED");
+            println!("✓ Single insert succeeded");
+        }
+        
+        // Verify we can read it back
+        let trie = trie_db::TrieDBBuilder::<L>::new(&memdb, &root).build();
+        let result = trie.get(b"value3").unwrap();
+        assert_eq!(result, Some(vec![142; 33]));
+        println!("✓ Single insert round-trip succeeded");
+    }
+
+    #[test] 
+    fn test_progressive_inserts() {
+        test_progressive_inserts_inner::<LayoutV1>();
+        test_progressive_inserts_inner::<LayoutV0>();
+    }
+
+    fn test_progressive_inserts_inner<L: TrieConfiguration>() {
+        use memory_db::{MemoryDB, HashKey};
+        use trie_db::{TrieDBMutBuilder, TrieMut};
+        
+        let mut memdb = MemoryDBMeta::<L::Hash>::new(&0u64.to_le_bytes());
+        let mut root = Default::default();
+        
+        {
+            let mut trie = TrieDBMutBuilder::<L>::new(&mut memdb, &mut root).build();
+            
+            // Insert values one by one to see exactly where it breaks
+            println!("Step 1: Inserting value3...");
+            trie.insert(b"value3", &[142; 33]).expect("Step 1 failed");
+            
+            println!("Step 2: Inserting value4...");
+            trie.insert(b"value4", &[124; 33]).expect("Step 2 failed");
+            
+            println!("Step 3: Inserting key...");
+            trie.insert(b"key", b"value").expect("Step 3 failed");
+            
+            println!("Step 4: Inserting value1...");
+            trie.insert(b"value1", &[42]).expect("Step 4 failed");
+            
+            println!("Step 5: Inserting value2...");
+            trie.insert(b"value2", &[24]).expect("Step 5 failed");
+            
+            println!("✓ All progressive inserts succeeded");
+        }
     }
 }

--- a/src/node_codec.rs
+++ b/src/node_codec.rs
@@ -165,13 +165,12 @@ where
                         length_array.copy_from_slice(length_bytes);
                         let count = u64::from_le_bytes(length_array) as usize;
                         
-                        // All children must be hashes (32 bytes) in zk-trie - no inline children
-                        if count != H::LENGTH {
-                            return Err(Error::BadFormat);
-                        }
-                        
-                        let range = input.take(H::LENGTH)?;
-                        children[i] = Some(NodeHandlePlan::Hash(range));
+                        let range = input.take(count)?;
+                        children[i] = Some(if count == H::LENGTH {
+                            NodeHandlePlan::Hash(range)
+                        } else {
+                            NodeHandlePlan::Inline(range)
+                        });
                     }
                 }
                 Ok(NodePlan::NibbledBranch {

--- a/src/node_codec.rs
+++ b/src/node_codec.rs
@@ -98,35 +98,13 @@ where
 
     fn decode_plan(data: &[u8]) -> Result<NodePlan, Self::Error> {
         log::debug!(target: "zk-trie", "NodeCodec::decode_plan called with data: {:02x?}", data);
-        
+
         // Handle empty data
         if data.is_empty() {
             log::debug!(target: "zk-trie", "NodeCodec::decode_plan: empty data, returning Empty node plan");
             return Ok(NodePlan::Empty);
         }
-        
-        // Handle the case where we're trying to decode a hash value instead of actual trie data
-        // This happens when the empty trie root hash is incorrectly treated as stored trie data
-        if data.len() == H::LENGTH {
-            let empty_hash = Self::hashed_null_node();
-            if data == empty_hash.as_ref() {
-                log::debug!(target: "zk-trie", "NodeCodec::decode_plan: detected empty trie root hash, returning Empty node plan");
-                return Ok(NodePlan::Empty);
-            }
-        }
-        
-        // Handle legacy single-byte empty trie representation
-        if data.len() == 1 && data[0] == 0 {
-            log::debug!(target: "zk-trie", "NodeCodec::decode_plan: detected legacy single-byte empty trie, returning Empty node plan");
-            return Ok(NodePlan::Empty);
-        }
-        
-        // Handle any other cases where data is too short for our 8-byte header format
-        if data.len() < 8 {
-            log::debug!(target: "zk-trie", "NodeCodec::decode_plan: data too short ({}), treating as empty trie", data.len());
-            return Ok(NodePlan::Empty);
-        }
-        
+
         let mut input = ByteSliceInput::new(data);
         let header = NodeHeader::decode(&mut input)?;
         let contains_hash = header.contains_hash_of_value();
@@ -186,12 +164,14 @@ where
                         let mut length_array = [0u8; 8];
                         length_array.copy_from_slice(length_bytes);
                         let count = u64::from_le_bytes(length_array) as usize;
-                        let range = input.take(count)?;
-                        children[i] = Some(if count == H::LENGTH {
-                            NodeHandlePlan::Hash(range)
-                        } else {
-                            NodeHandlePlan::Inline(range)
-                        });
+                        
+                        // All children must be hashes (32 bytes) in zk-trie - no inline children
+                        if count != H::LENGTH {
+                            return Err(Error::BadFormat);
+                        }
+                        
+                        let range = input.take(H::LENGTH)?;
+                        children[i] = Some(NodeHandlePlan::Hash(range));
                     }
                 }
                 Ok(NodePlan::NibbledBranch {

--- a/src/node_codec.rs
+++ b/src/node_codec.rs
@@ -164,7 +164,7 @@ where
                         let mut length_array = [0u8; 8];
                         length_array.copy_from_slice(length_bytes);
                         let count = u64::from_le_bytes(length_array) as usize;
-                        
+
                         let range = input.take(count)?;
                         children[i] = Some(if count == H::LENGTH {
                             NodeHandlePlan::Hash(range)

--- a/src/storage_proof.rs
+++ b/src/storage_proof.rs
@@ -159,8 +159,6 @@ impl StorageProof {
         let compact_proof = self.into_compact_proof::<H>(root);
         compact_proof.ok().map(|p| p.encoded_size())
     }
-
-
 }
 
 impl<H: Hasher> From<StorageProof> for crate::MemoryDB<H> {
@@ -184,8 +182,6 @@ impl<H: Hasher> From<&StorageProof> for crate::MemoryDB<H> {
 pub struct CompactProof {
     pub encoded_nodes: Vec<Vec<u8>>,
 }
-
-
 
 impl CompactProof {
     /// Return an iterator on the compact encoded nodes.
@@ -238,13 +234,12 @@ impl CompactProof {
     }
 }
 
-
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
     use crate::{tests::create_storage_proof, StorageProof};
 
+    type Hasher = sp_core::Blake2Hasher;
     type Layout = crate::LayoutV1<sp_core::Blake2Hasher>;
 
     const TEST_DATA: &[(&[u8], &[u8])] = &[
@@ -261,5 +256,14 @@ pub mod tests {
             StorageProof::new_with_duplicate_nodes_check(raw_proof),
             Err(StorageProofError::DuplicateNodes)
         ));
+    }
+
+    #[test]
+    fn invalid_compact_proof_does_not_panic_when_decoding() {
+        let invalid_proof = CompactProof {
+            encoded_nodes: vec![vec![135]],
+        };
+        let result = invalid_proof.to_memory_db::<Hasher>(None);
+        assert!(result.is_err());
     }
 }

--- a/src/storage_proof.rs
+++ b/src/storage_proof.rs
@@ -20,10 +20,12 @@ use codec::{Decode, Encode};
 use core::iter::{DoubleEndedIterator, IntoIterator};
 use hash_db::{HashDB, Hasher};
 use scale_info::TypeInfo;
+use trie_db::Trie;
 
 // Note that `LayoutV1` usage here (proof compaction) is compatible
 // with `LayoutV0`.
 use crate::LayoutV1 as Layout;
+use crate::encode_felt_aligned_compact;
 
 /// Error associated with the `storage_proof` module.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, Debug, TypeInfo)]
@@ -159,6 +161,24 @@ impl StorageProof {
         let compact_proof = self.into_compact_proof::<H>(root);
         compact_proof.ok().map(|p| p.encoded_size())
     }
+
+    /// Encode as a felt-aligned compact proof that properly handles boundary detection.
+    pub fn into_felt_aligned_compact_proof<H: Hasher>(
+        self,
+        root: H::Out,
+    ) -> Result<FeltAlignedCompactProof, crate::CompactProofError<H::Out, crate::Error<H::Out>>> {
+        let db = self.into_memory_db();
+        encode_felt_aligned_compact::<Layout<H>, crate::MemoryDB<H>>(&db, &root)
+    }
+
+    /// Encode as a felt-aligned compact proof that properly handles boundary detection.
+    pub fn to_felt_aligned_compact_proof<H: Hasher>(
+        &self,
+        root: H::Out,
+    ) -> Result<FeltAlignedCompactProof, crate::CompactProofError<H::Out, crate::Error<H::Out>>> {
+        let db = self.to_memory_db();
+        encode_felt_aligned_compact::<Layout<H>, crate::MemoryDB<H>>(&db, &root)
+    }
 }
 
 impl<H: Hasher> From<StorageProof> for crate::MemoryDB<H> {
@@ -181,6 +201,26 @@ impl<H: Hasher> From<&StorageProof> for crate::MemoryDB<H> {
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, TypeInfo)]
 pub struct CompactProof {
     pub encoded_nodes: Vec<Vec<u8>>,
+}
+
+/// Felt-aligned aware compact proof that properly handles boundary detection
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, TypeInfo)]
+pub struct FeltAlignedCompactProof {
+    /// Encoded nodes with explicit boundary markers
+    pub encoded_nodes: Vec<Vec<u8>>,
+    /// Metadata about node boundaries to prevent confusion
+    pub node_boundaries: Vec<NodeBoundary>,
+}
+
+/// Boundary information for felt-aligned nodes
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, TypeInfo)]
+pub struct NodeBoundary {
+    /// Start offset in the encoded data
+    pub start: u32,
+    /// Length of the actual node data (excluding padding)
+    pub length: u32,
+    /// Whether this contains value data that might look like headers
+    pub has_value_data: bool,
 }
 
 impl CompactProof {
@@ -231,6 +271,162 @@ impl CompactProof {
         )?;
 
         Ok((db, root))
+    }
+}
+
+impl FeltAlignedCompactProof {
+    /// Create a new felt-aligned compact proof from node data
+    pub fn new(encoded_nodes: Vec<Vec<u8>>) -> Self {
+        let node_boundaries = encoded_nodes
+            .iter()
+            .enumerate()
+            .map(|(i, node)| {
+                // Analyze if this node contains value data that might look like headers
+                let has_value_data = Self::node_contains_problematic_value_data(node);
+                NodeBoundary {
+                    start: i as u32,
+                    length: node.len() as u32,
+                    has_value_data,
+                }
+            })
+            .collect();
+
+        Self {
+            encoded_nodes,
+            node_boundaries,
+        }
+    }
+
+    /// Create a new felt-aligned compact proof from storage proof format
+    pub fn new_from_storage_proof(proof_nodes: Vec<Vec<u8>>) -> Self {
+        // Simple wrapper that preserves storage proof semantics
+        let node_boundaries = proof_nodes
+            .iter()
+            .enumerate()
+            .map(|(i, node)| NodeBoundary {
+                start: i as u32,
+                length: node.len() as u32,
+                has_value_data: false, // Storage proof format is safe
+            })
+            .collect();
+
+        Self {
+            encoded_nodes: proof_nodes,
+            node_boundaries,
+        }
+    }
+
+    /// Check if a node contains value data that might be confused with headers
+    fn node_contains_problematic_value_data(node_data: &[u8]) -> bool {
+        if node_data.len() < 16 {
+            return false;
+        }
+
+        // Only flag nodes that contain repeating value patterns that are likely
+        // to be the problematic cases we identified earlier
+        let mut consecutive_same_bytes = 0;
+        let mut last_byte = node_data[0];
+        
+        for &byte in &node_data[1..] {
+            if byte == last_byte {
+                consecutive_same_bytes += 1;
+                // If we have 16+ consecutive identical bytes, this might be 
+                // the repeating value data we saw in the debug output
+                if consecutive_same_bytes >= 15 {
+                    return true;
+                }
+            } else {
+                consecutive_same_bytes = 0;
+                last_byte = byte;
+            }
+        }
+        
+        false
+    }
+
+    /// Return an iterator on the encoded nodes with boundary awareness
+    pub fn iter_nodes_with_boundaries(&self) -> impl Iterator<Item = (&[u8], &NodeBoundary)> {
+        self.encoded_nodes
+            .iter()
+            .zip(self.node_boundaries.iter())
+            .map(|(node, boundary)| (node.as_slice(), boundary))
+    }
+
+    /// Get the total encoded size
+    pub fn encoded_size(&self) -> usize {
+        self.encoded_nodes.iter().map(|n| n.len()).sum::<usize>() +
+            self.node_boundaries.len() * core::mem::size_of::<NodeBoundary>()
+    }
+
+    /// Convert to standard CompactProof format (unsafe - may cause boundary issues)
+    pub fn to_compact_proof(&self) -> CompactProof {
+        CompactProof {
+            encoded_nodes: self.encoded_nodes.clone(),
+        }
+    }
+
+    /// Decode to a full storage proof using felt-aligned aware decoding
+    pub fn to_storage_proof<H: Hasher>(
+        &self,
+        expected_root: Option<&H::Out>,
+    ) -> Result<(StorageProof, H::Out), crate::CompactProofError<H::Out, crate::Error<H::Out>>>
+    {
+        // Simple approach: if we created this from storage proof format,
+        // we can safely reconstruct the storage proof directly
+        if self.node_boundaries.iter().all(|b| !b.has_value_data) {
+            // This was created from safe storage proof format
+            let storage_proof = StorageProof::new(self.encoded_nodes.clone());
+            
+            // Validate the root by creating a memory DB and checking
+            let db = storage_proof.to_memory_db::<H>();
+            if let Some(expected_root) = expected_root {
+                let trie = crate::TrieDBBuilder::<Layout<H>>::new(&db, expected_root).build();
+                let root = *trie.root();
+                return Ok((storage_proof, root));
+            } else {
+                // Without expected root, we can't validate easily, but return the storage proof
+                return Err(crate::trie_codec::Error::IncompleteProof.into());
+            }
+        }
+        
+        // Fallback to boundary-aware decoding for complex cases
+        let mut db = crate::MemoryDB::<H>::new(&[]);
+        let root = self.decode_with_boundary_awareness::<H>(&mut db, expected_root)?;
+
+        Ok((
+            StorageProof::new(db.drain().into_iter().filter_map(|kv| {
+                if (kv.1).1 > 0 {
+                    Some((kv.1).0)
+                } else {
+                    None
+                }
+            })),
+            root,
+        ))
+    }
+
+    /// Custom decoder that respects felt-alignment boundaries
+    fn decode_with_boundary_awareness<H: Hasher>(
+        &self,
+        db: &mut crate::MemoryDB<H>,
+        expected_root: Option<&H::Out>,
+    ) -> Result<H::Out, crate::CompactProofError<H::Out, crate::Error<H::Out>>> {
+        // Simplified approach: insert all nodes directly into DB and validate
+        for node in &self.encoded_nodes {
+            db.insert(crate::EMPTY_PREFIX, node);
+        }
+        
+        // Validate the expected root exists
+        if let Some(expected_root) = expected_root {
+            if !db.contains(expected_root, crate::EMPTY_PREFIX) {
+                return Err(crate::trie_codec::Error::IncompleteProof.into());
+            }
+            Ok(*expected_root)
+        } else {
+            // If no expected root provided, return the first hash we can find
+            // This is a fallback case
+            Err(crate::trie_codec::Error::IncompleteProof.into())
+        }
     }
 }
 

--- a/src/trie_codec.rs
+++ b/src/trie_codec.rs
@@ -21,9 +21,8 @@
 //! it to substrate specific layout and child trie system.
 
 use crate::{CompactProof, HashDBT, TrieConfiguration, TrieHash, EMPTY_PREFIX};
-use alloc::{boxed::Box, collections::BTreeSet, vec::Vec};
-use hash_db::{HashDBRef, Hasher};
-use trie_db::{CError, NodeCodec, Trie};
+use alloc::{boxed::Box, vec::Vec};
+use trie_db::{CError, Trie};
 
 /// Error for trie node decoding.
 #[derive(Debug)]
@@ -211,5 +210,3 @@ where
         encoded_nodes: compact_proof,
     })
 }
-
-


### PR DESCRIPTION
Many tests were failing in the chain when we connected this to it. It was mostly due to PrefixedMemoryDB and MemoryDB having .default() return a single null byte instead of 8 null bytes. So we overwrote the Default trait by wrapping these types. We also remove a sloppy patch that was trying to address this from before. There were also a bunch of corner cases that were not tested in this repo but were in sp-state-machine so we added similar tests here.

